### PR TITLE
fix: correct dumped size

### DIFF
--- a/windows/x64/kernel/crucial_Ballistix_MOD_Utility_v.2.0.2.5/crucial_Ballistix_MOD_Utility_v.2.0.2.5_memory_dump_PoC.cpp
+++ b/windows/x64/kernel/crucial_Ballistix_MOD_Utility_v.2.0.2.5/crucial_Ballistix_MOD_Utility_v.2.0.2.5_memory_dump_PoC.cpp
@@ -77,7 +77,7 @@ int main()
 		<< " bytes of data from 0x" << hex << uppercase << setw(16) << setfill('0') << PhysicalMemAddr << endl;
 	cout << string(70, '-') << endl;
 	// pretty print memory dump
-	for (int nSize = 0; nSize <= 0x32; nSize += 0x10)
+	for (int nSize = 0; nSize < 32; nSize += 0x10)
 	{
 		for (int i = 0; i <= 0xF; i++)
 		{


### PR DESCRIPTION
Fix a bug that the PoC only read `dwDataSizeToRead * dwAmountOfDataToRead`, but the script prints 64 bytes.